### PR TITLE
Fix undefined checksum for installer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ install_rust: true
 
 # Solana variables
 
-solana_installer_version: v1.8.15
+solana_installer_version: v1.10.0
 
 solana_version: stable
 


### PR DESCRIPTION
Fixes https://github.com/rpcpool/solana-rpc-ansible/issues/8

Use a version of the installer for which we have a checksum in `vars/main.yml`.

Note: it looks like the checksum from v1.8.15 -> 1.8.16 changed, so that version isn't available, unless you want me to update that as well.